### PR TITLE
fix: update healthcheck url

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,8 +60,8 @@ func main() {
 			http.HandlerFunc
 		}{
 			func(w http.ResponseWriter, r *http.Request) {
-				// GET / can be used as live-ness probe
-				if r.Method == http.MethodGet {
+				// GET /healthcheck can be used as readiness probe
+				if r.Method == http.MethodGet && r.URL.Path == "/healthcheck" {
 					w.WriteHeader(http.StatusOK)
 					return
 				}


### PR DESCRIPTION
Change the path of the readiness probe from `/` to `/healthcheck`

```
[peter@fedora observability-remote-write-proxy]$ curl -i localhost:8080
HTTP/1.1 400 Bad Request
Date: Tue, 21 Feb 2023 09:28:43 GMT
Content-Length: 0

[peter@fedora observability-remote-write-proxy]$ curl -i localhost:8080/healthcheck
HTTP/1.1 200 OK
Date: Tue, 21 Feb 2023 09:28:47 GMT
Content-Length: 0
```