### PR TITLE
feat: add ability to specify a CA certificate to use for TLS verification during Token Verification stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-REGISTRY=quay.io/rhoas
-IMAGE_NAME=observability-remote-write-proxy
-VERSION=$$(git rev-parse --short=7 HEAD)
+REGISTRY ?= quay.io/rhoas
+IMAGE_NAME ?= observability-remote-write-proxy
+VERSION ?= "$$(git rev-parse --short=7 HEAD)"
 
 docker/login:
 	docker --config=${DOCKER_CONFIG} login -u ${QUAY_USER} -p ${QUAY_TOKEN} quay.io

--- a/api/types.go
+++ b/api/types.go
@@ -2,10 +2,11 @@ package api
 
 import (
 	"errors"
-	"gopkg.in/yaml.v3"
 	"io"
 	"net/url"
 	"os"
+
+	"gopkg.in/yaml.v3"
 )
 
 type ProxyConfig struct {
@@ -28,8 +29,23 @@ type OIDCAttributes struct {
 }
 
 type TokenVerificationConfig struct {
-	Enabled *bool
-	Url     *string
+	Enabled        *bool
+	Url            *string
+	CACertEnabled  *bool
+	CACertFilePath *string
+
+	CACertReader io.Reader
+}
+
+func (c *TokenVerificationConfig) ReadCACert() ([]byte, error) {
+	var caCertRawBytes []byte
+	data, err := io.ReadAll(c.CACertReader)
+	if err != nil {
+		return nil, err
+	}
+	caCertRawBytes = data
+
+	return caCertRawBytes, nil
 }
 
 func (c *OIDCConfig) Read() error {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	go.buf.build/protocolbuffers/go/prometheus/prometheus v1.3.5
 	golang.org/x/oauth2 v0.4.0
 	google.golang.org/protobuf v1.28.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -29,5 +30,4 @@ require (
 	golang.org/x/text v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Description

One of the stages that Observability Remote Write Proxy goes through is the token verification stage.
For that, it needs to contact a token verifier endpoint (KFM for example).
Sometimes the connection against the token verifier endpoint is an HTTPS connection (using TLS).

This PR adds functionality to allow Observability Remote Write Proxy to use a provided CA certificate during the token verification stage. In that case, if the HTTPS token verifier endpoint uses a self-signed certificate and that certificate is issued by the CA provided in the certificate it will be considered as valid.

The way it is implemented is that this CA certificate is *appended* to the system's pool of certificates during that phase.