### PR TITLE
Log invalid requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,8 @@ func main() {
 
 				// POST / is the only accepted endpoint for incoming write requests
 				if r.Method != http.MethodPost || r.URL.Path != "/" {
-					log.Println("invalid proxy request, method must be POST and path must be /")
+					log.Println(fmt.Sprintf("invalid proxy request, method must be POST and path must be /, but got method %v and path %v",
+						r.Method, r.URL.Path))
 					w.WriteHeader(http.StatusBadRequest)
 					return
 				}

--- a/pkg/remotewrite/validate.go
+++ b/pkg/remotewrite/validate.go
@@ -24,6 +24,10 @@ func FindClusterIDs(req *prometheus.WriteRequest) map[string]int {
 	return clusterID
 }
 
+func IsMetadataRequest(remoteWriteRequest *prometheus.WriteRequest) bool {
+	return remoteWriteRequest != nil && len(remoteWriteRequest.Timeseries) == 0 && len(remoteWriteRequest.Metadata) != 0
+}
+
 // ValidateRequest validates a remote write request
 func ValidateRequest(remoteWriteRequest *prometheus.WriteRequest) (string, error) {
 	clusterIDs := FindClusterIDs(remoteWriteRequest)

--- a/pkg/remotewrite/validate.go
+++ b/pkg/remotewrite/validate.go
@@ -37,5 +37,6 @@ func ValidateRequest(remoteWriteRequest *prometheus.WriteRequest) (string, error
 		return key, nil
 	}
 
-	return "", errors.New("request does not contain any cluster ids")
+	message := fmt.Sprintf("request does not contain any cluster ids: %v", remoteWriteRequest)
+	return "", errors.New(message)
 }


### PR DESCRIPTION
* additional logging for why requests are denied
* we need to let Prometheus metadata requests through without verification (there are no labels and thus no cluster ids on them)