### PR TITLE
feat: additional logs when requests are denied

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,8 @@ func main() {
 
 				// POST / is the only accepted endpoint for incoming write requests
 				if r.Method != http.MethodPost || r.URL.Path != "/" {
-					log.Println("invalid proxy request, method must be POST and path must be /")
+					log.Println(fmt.Sprintf("invalid proxy request, method must be POST and path must be /, but got method %v and path %v",
+						r.Method, r.URL.Path))
 					w.WriteHeader(http.StatusBadRequest)
 					return
 				}

--- a/pkg/remotewrite/validate.go
+++ b/pkg/remotewrite/validate.go
@@ -37,5 +37,5 @@ func ValidateRequest(remoteWriteRequest *prometheus.WriteRequest) (string, error
 		return key, nil
 	}
 
-	return "", errors.New("request does not contain any cluster ids")
+	return "", fmt.Errorf("request does not contain any cluster ids: %v", remoteWriteRequest)
 }


### PR DESCRIPTION
* Log details about requests with invalid methods or paths.
* Log the whole remote write request if it doesn't contain any cluster_ids.